### PR TITLE
Linkify Address, Zone under AAAA table

### DIFF
--- a/changes/70.fixed
+++ b/changes/70.fixed
@@ -1,0 +1,1 @@
+Added links for Address and Zone under the AAAA table.

--- a/nautobot_dns_models/tables.py
+++ b/nautobot_dns_models/tables.py
@@ -133,6 +133,8 @@ class AAAARecordModelTable(BaseTable):
 
     pk = ToggleColumn()
     name = tables.Column(linkify=True)
+    address = tables.LinkColumn()
+    zone = tables.LinkColumn()
     actions = ButtonsColumn(
         models.AAAARecordModel,
         # Option for modifying the default action buttons on each row:


### PR DESCRIPTION
Closes: #70

## What's Changed
Links were added for Address and Zone under the AAAA table.

![image](https://github.com/user-attachments/assets/5ecbe240-96ec-4995-8bb7-b22f75e9373d)

## To Do
- [X] Explanation of Change(s)
- [X] Added change log fragment(s)
- [X] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
