### PR TITLE
Release v1.2.2

### DIFF
--- a/changes/113.added
+++ b/changes/113.added
@@ -1,1 +1,0 @@
-Add q SearchFilter to DNSZoneFilterSet to enable API q= search.

--- a/changes/122.added
+++ b/changes/122.added
@@ -1,1 +1,0 @@
-Added q SearchFilter for models to enable global search.

--- a/docs/admin/release_notes/version_1.2.md
+++ b/docs/admin/release_notes/version_1.2.md
@@ -8,6 +8,13 @@ This document describes all new features and changes in the release. The format 
 - This release makes DNS models globally searchable in Nautobot and added DNS name length validation per RFC 1035.
 - Changes to compatibility with Nautobot and/or other apps, libraries etc.
 
+## [v1.2.2 (2025-09-26)](https://github.com/nautobot/nautobot-app-dns-models/releases/tag/v1.2.2)
+
+### Added
+
+- [#113](https://github.com/nautobot/nautobot-app-dns-models/issues/113) - Add q SearchFilter to DNSZoneFilterSet to enable API q= search.
+- [#122](https://github.com/nautobot/nautobot-app-dns-models/issues/122) - Added q SearchFilter for models to enable global search.
+
 ## [v1.2.1 (2025-09-16)](https://github.com/nautobot/nautobot-app-dns-models/releases/tag/v1.2.1)
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-dns-models"
-version = "1.2.2a0"
+version = "1.2.2"
 description = "Nautobot DNS Models"
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## [v1.2.2 (2025-09-26)](https://github.com/nautobot/nautobot-app-dns-models/releases/tag/v1.2.2)

### Added

- [#113](https://github.com/nautobot/nautobot-app-dns-models/issues/113) - Add q SearchFilter to DNSZoneFilterSet to enable API q= search.
- [#122](https://github.com/nautobot/nautobot-app-dns-models/issues/122) - Added q SearchFilter for models to enable global search.
