### PR TITLE
Updated SRVRecordType to have the corred model and filterset_class

### DIFF
--- a/nautobot_dns_models/graphql/types.py
+++ b/nautobot_dns_models/graphql/types.py
@@ -116,9 +116,6 @@ class SRVRecordType(DNSRecordType):
         model = SRVRecord
         filterset_class = SRVRecordFilterSet
 
-        model = PTRRecord
-        filterset_class = PTRRecordFilterSet
-
 
 graphql_types = [
     NSRecordType,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot DNS Models! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #130 

## What's Changed
When moving `gaphql/types.py` to `nautobot-dns-apps-models` the `SRVRecordType` referenced the `PTRRecord` `filterset_class`.



```python
class SRVRecordType(DNSRecordType):
    """Graphql Type Object for the SRVRecord model."""

    class Meta:
        """Metadata for the SRVRecord."""

        model = SRVRecord
        filterset_class = SRVRecordFilterSet
```

## Proof

**Query**
```graphql
query {
  srv_records(zone: "32ed962f-c6bf-4412-a12d-1e2544e85a50") {
    name
    ttl
    zone {
      name
    }
  }
}
```

***Before***

```json
{
  "errors": [
    {
      "message": "Cannot query field \"srv_records\" on type \"Query\". Did you mean \"ns_records\", \"a_records\", \"mx_records\", \"txt_records\" or \"ptr_records\"?",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ]
    }
  ]
}
```

***After***
```json
{
  "data": {
    "srv_records": [
      {
        "name": "tcp_test",
        "ttl": 300,
        "zone": {
          "name": "test.test"
        }
      }
    ]
  }
}
```
