### PR TITLE
Release v1.3.1

### DIFF
--- a/changes/+nautobot-app-v2.7.1.housekeeping
+++ b/changes/+nautobot-app-v2.7.1.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.1`.

--- a/changes/+nautobot-app-v2.7.2.housekeeping
+++ b/changes/+nautobot-app-v2.7.2.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.2`.

--- a/changes/161.fixed
+++ b/changes/161.fixed
@@ -1,1 +1,0 @@
-Fixed AAAA records creation link in DNS zones item object view.

--- a/changes/162.added
+++ b/changes/162.added
@@ -1,1 +1,0 @@
-Added the `nautobot_dns_models_dns_views` filter extension to the `ipam.Prefix` model to allow filtering prefixes by DNS views.

--- a/changes/162.fixed
+++ b/changes/162.fixed
@@ -1,1 +1,0 @@
-Fixed the filter for the badge link on the Assigned Prefixes panel in the DNS View detail view.

--- a/changes/170.fixed
+++ b/changes/170.fixed
@@ -1,1 +1,0 @@
-Fixed accessing django settings at runtime preventing the Python package from loading.

--- a/docs/admin/release_notes/version_1.3.md
+++ b/docs/admin/release_notes/version_1.3.md
@@ -8,6 +8,22 @@ This document describes all new features and changes in the release. The format 
 - Changes to compatibility with Nautobot and/or other apps, libraries etc.
 
 <!-- towncrier release notes start -->
+## [v1.3.1 (2025-12-12)](https://github.com/nautobot/nautobot-app-dns-models/releases/tag/v1.3.1)
+
+### Added
+
+- [#162](https://github.com/nautobot/nautobot-app-dns-models/issues/162) - Added the `nautobot_dns_models_dns_views` filter extension to the `ipam.Prefix` model to allow filtering prefixes by DNS views.
+
+### Fixed
+
+- [#161](https://github.com/nautobot/nautobot-app-dns-models/issues/161) - Fixed a bug when trying to create AAAA records for a DNS View.
+- [#162](https://github.com/nautobot/nautobot-app-dns-models/issues/162) - Fixed the filter for the badge link on the Assigned Prefixes panel in the DNS View detail view.
+- [#170](https://github.com/nautobot/nautobot-app-dns-models/issues/170) - Fixed a bug preventing the Python package from loading in some cases.
+
+### Housekeeping
+
+- Rebaked from the cookie `nautobot-app-v2.7.1`.
+- Rebaked from the cookie `nautobot-app-v2.7.2`.
 
 ## [v1.3.0 (2025-10-29)](https://github.com/nautobot/nautobot-app-dns-models/releases/tag/v1.3.0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-dns-models"
-version = "1.3.1a0"
+version = "1.3.1"
 description = "Nautobot DNS Models"
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## [v1.3.1 (2025-12-12)](https://github.com/nautobot/nautobot-app-dns-models/releases/tag/v1.3.1)

### Added

- [#162](https://github.com/nautobot/nautobot-app-dns-models/issues/162) - Added the `nautobot_dns_models_dns_views` filter extension to the `ipam.Prefix` model to allow filtering prefixes by DNS views.

### Fixed

- [#161](https://github.com/nautobot/nautobot-app-dns-models/issues/161) - Fixed a bug when trying to create AAAA records for a DNS View.
- [#162](https://github.com/nautobot/nautobot-app-dns-models/issues/162) - Fixed the filter for the badge link on the Assigned Prefixes panel in the DNS View detail view.
- [#170](https://github.com/nautobot/nautobot-app-dns-models/issues/170) - Fixed a bug preventing the Python package from loading in some cases.

### Housekeeping

- Rebaked from the cookie `nautobot-app-v2.7.1`.
- Rebaked from the cookie `nautobot-app-v2.7.2`.