### PR TITLE
chore: add DNS view name in zone's __str__

### DIFF
--- a/changes/221.changed
+++ b/changes/221.changed
@@ -1,0 +1,1 @@
+Added DNS view in the DNS zone's reference `__str__`.

--- a/nautobot_dns_models/forms.py
+++ b/nautobot_dns_models/forms.py
@@ -233,6 +233,7 @@ class DNSZoneForm(NautobotModelForm, TenancyForm):
     dns_view = DynamicModelChoiceField(
         queryset=models.DNSView.objects.all(),
         required=True,
+        label="View",
     )
 
     class Meta:

--- a/nautobot_dns_models/models.py
+++ b/nautobot_dns_models/models.py
@@ -276,6 +276,10 @@ class DNSZone(DNSModel):
         verbose_name = "DNS Zone"
         verbose_name_plural = "DNS Zones"
 
+    def __str__(self):
+        """Stringify instance."""
+        return f"{self.name} ({self.dns_view})"
+
     @classmethod
     def find_reverse_zone_for_ptrdname(cls, ptrdname, dns_view=None):
         """Return the most-specific reverse DNSZone whose name matches a tail of `ptrdname`, otherwise None."""

--- a/nautobot_dns_models/template_content.py
+++ b/nautobot_dns_models/template_content.py
@@ -57,7 +57,8 @@ class ForwardDNSRecordsTablePanel(ObjectsTablePanel):
             name, zone = ip_address.dns_name.split(".", 1)
         except ValueError:
             name = zone = ""
-        # TODO:If multiple zones exist with the same name, this will just get the first one.
+
+        # If multiple zones exist with the same name, this will just get the first one.
         # This is a best effort to autopopulate the zone field, but it won't be perfect in all cases.
         zone_obj = DNSZone.objects.filter(name=zone).first()
         if zone_obj:

--- a/nautobot_dns_models/tests/test_models.py
+++ b/nautobot_dns_models/tests/test_models.py
@@ -157,7 +157,7 @@ class TestDnsZone(ModelTestCases.BaseModelTestCase):
         dnszone = DNSZone.objects.create(name="Development")
         self.assertEqual(dnszone.name, "Development")
         self.assertEqual(dnszone.description, "")
-        self.assertEqual(str(dnszone), "Development")
+        self.assertEqual(str(dnszone), "Development (Default)")
 
     def test_create_dnszone_all_fields_success(self):
         """Create DnsZoneModel with all fields."""


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot DNS Models! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: N/A

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Added DNS view's name in the DNS Zones reference (`__str__`) to avoid confusion. As an example:
<img width="1171" height="73" alt="image" src="https://github.com/user-attachments/assets/c4fc3734-49c1-4444-b07d-768a71f540db" />


## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
