### PR TITLE
Sync 'ruff' and 'pylint' targets with current cookiecutter

### DIFF
--- a/changes/216.changed
+++ b/changes/216.changed
@@ -1,0 +1,1 @@
+Re-sync invoke lint tasks with cookiecutter by adding `pylint` `target`/`recursive` options and `ruff` `--diff` support.

--- a/tasks.py
+++ b/tasks.py
@@ -780,26 +780,49 @@ def hadolint(context):
     run_command(context, command)
 
 
-@task
-def pylint(context):
+@task(
+    help={
+        "target": "Module or file or directory to inspect, repeatable (default: app package)",
+        "recursive": "Must be set if target is a directory rather than a module or file name",
+    },
+    iterable=["target"],
+)
+def pylint(context, target=None, recursive=False):
     """Run pylint code analysis."""
     exit_code = 0
 
     base_pylint_command = 'pylint --verbose --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml'
-    command = f"{base_pylint_command} nautobot_dns_models"
+    command = base_pylint_command
+    if recursive:
+        command += " --recursive=y"
+    command += f" {' '.join(target) if target else 'nautobot_dns_models'}"
     if not run_command(context, command, warn=True):
         exit_code = 1
 
     # run the pylint_django migrations checkers on the migrations directory, if one exists
-    migrations_dir = Path(__file__).absolute().parent / Path("nautobot_dns_models") / Path("migrations")
+    app_dir = Path(__file__).absolute().parent / Path("nautobot_dns_models")
+    migrations_dir = app_dir / Path("migrations")
+    migrations_target_module = "nautobot_dns_models.migrations"
+    run_migrations_check = target is None
+    if target is not None:
+        for target_item in target:
+            target_item_normalized = Path(target_item).resolve()
+            if (
+                target_item_normalized in (app_dir, migrations_dir)
+                or target_item == migrations_target_module
+            ):
+                run_migrations_check = True
+                break
+
     if migrations_dir.is_dir():
-        migrations_pylint_command = (
-            f"{base_pylint_command} --load-plugins=pylint_django.checkers.migrations"
-            " --disable=all --enable=fatal,new-db-field-with-default,missing-backwards-migration-callable"
-            " nautobot_dns_models.migrations"
-        )
-        if not run_command(context, migrations_pylint_command, warn=True):
-            exit_code = 1
+        if run_migrations_check:
+            migrations_pylint_command = (
+                f"{base_pylint_command} --load-plugins=pylint_django.checkers.migrations"
+                " --disable=all --enable=fatal,new-db-field-with-default,missing-backwards-migration-callable"
+                f" {migrations_target_module}"
+            )
+            if not run_command(context, migrations_pylint_command, warn=True):
+                exit_code = 1
     else:
         print("No migrations directory found, skipping migrations checks.")
 

--- a/tasks.py
+++ b/tasks.py
@@ -807,10 +807,7 @@ def pylint(context, target=None, recursive=False):
     if target is not None:
         for target_item in target:
             target_item_normalized = Path(target_item).resolve()
-            if (
-                target_item_normalized in (app_dir, migrations_dir)
-                or target_item == migrations_target_module
-            ):
+            if target_item_normalized in (app_dir, migrations_dir) or target_item == migrations_target_module:
                 run_migrations_check = True
                 break
 

--- a/tasks.py
+++ b/tasks.py
@@ -819,11 +819,12 @@ def autoformat(context):
         "action": "Available values are `['lint', 'format']`. Can be used multiple times. (default: `--action lint --action format`)",
         "target": "File or directory to inspect, repeatable (default: all files in the project will be inspected)",
         "fix": "Automatically fix selected actions. May not be able to fix all issues found. (default: False)",
+        "diff": "Show diff of changes. (default: False)",
         "output_format": "See https://docs.astral.sh/ruff/settings/#output-format for details. (default: `concise`)",
     },
     iterable=["action", "target"],
 )
-def ruff(context, action=None, target=None, fix=False, output_format="concise"):
+def ruff(context, action=None, target=None, fix=False, diff=False, output_format="concise"):
     """Run ruff to perform code formatting and/or linting."""
     if not action:
         action = ["lint", "format"]
@@ -836,6 +837,8 @@ def ruff(context, action=None, target=None, fix=False, output_format="concise"):
         command = "ruff format "
         if not fix:
             command += "--check "
+            if diff:
+                command += "--diff "
         command += " ".join(target)
         if not run_command(context, command, warn=True):
             exit_code = 1
@@ -844,6 +847,8 @@ def ruff(context, action=None, target=None, fix=False, output_format="concise"):
         command = "ruff check "
         if fix:
             command += "--fix "
+        elif diff:
+            command += "--diff "
         command += f"--output-format {output_format} "
         command += " ".join(target)
         if not run_command(context, command, warn=True):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot DNS Models! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #216 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Syncs behavior with the changes in the cookiecutter repo:

- `invoke pylint`
  - Added repeatable `--target` (`-t`) option.
  - Added `--recursive` (`-r`) option.
  - Kept default behavior (`invoke pylint` still targets `nautobot_dns_models`).
  - Preserved migrations checker behavior with target-aware gating.
- `invoke ruff`
  - Added `--diff` support for both:
    - `--action lint` (`ruff check --diff`)
    - `--action format` (`ruff format --check --diff`)


### Validation matrix and command output
For demonstration, I temporarily created `nautobot_dns_models/_issue216_demo.py` with deliberate lint/format problems, ran the matrix below, then deleted the file so the working tree was restored.

#### Pylint with `-t` (new syntax)
```bash
invoke pylint --target nautobot_dns_models/_issue216_demo.py

Running docker compose command "ps --services --filter status=running"
Running docker compose command "exec nautobot pylint --verbose --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml nautobot_dns_models/_issue216_demo.py"
04:47:57.838 INFO    nautobot             __init__.py                              setup() : Nautobot 3.0.0 initialized!
Using config file pyproject.toml
Get ASTs.
AST for nautobot_dns_models/_issue216_demo.py
Linting 1 modules.
nautobot_dns_models/_issue216_demo.py (1 of 1)
************* Module nautobot_dns_models._issue216_demo
nautobot_dns_models/_issue216_demo.py:4:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
nautobot_dns_models/_issue216_demo.py:1:0: C0114: Missing module docstring (missing-module-docstring)
nautobot_dns_models/_issue216_demo.py:1:0: C0410: Multiple imports on one line (os, sys) (multiple-imports)
nautobot_dns_models/_issue216_demo.py:3:0: C0116: Missing function or method docstring (missing-function-docstring)
nautobot_dns_models/_issue216_demo.py:6:0: C0103: Constant name "result" doesn't conform to UPPER_CASE naming style (invalid-name)
nautobot_dns_models/_issue216_demo.py:1:0: W0611: Unused import os (unused-import)
nautobot_dns_models/_issue216_demo.py:1:0: W0611: Unused import sys (unused-import)

----------------------------------------------------------------------------------------------------------------------------
Your code has been rated at 0.00/10
Checked 1 files/modules (nautobot_dns_models/_issue216_demo.py), skipped 1 files/modules
```

#### Pylint without -t (existing/default syntax)

```bash
invoke pylint

Running docker compose command "ps --services --filter status=running"
Running docker compose command "exec nautobot pylint --verbose --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml nautobot_dns_models"
04:48:05.889 INFO    nautobot             __init__.py                              setup() : Nautobot 3.0.0 initialized!
Using config file pyproject.toml
Get ASTs.
AST for nautobot_dns_models/__init__.py
AST for nautobot_dns_models/template_content.py
AST for nautobot_dns_models/models.py
AST for nautobot_dns_models/_issue216_demo.py
AST for nautobot_dns_models/forms.py
AST for nautobot_dns_models/jobs.py
AST for nautobot_dns_models/filter_extensions.py
AST for nautobot_dns_models/tables.py
AST for nautobot_dns_models/navigation.py
AST for nautobot_dns_models/urls.py
AST for nautobot_dns_models/filters.py
AST for nautobot_dns_models/views.py
AST for nautobot_dns_models/tests/test_forms.py
AST for nautobot_dns_models/tests/__init__.py
AST for nautobot_dns_models/tests/test_views.py
AST for nautobot_dns_models/tests/test_models.py
AST for nautobot_dns_models/tests/test_jobs.py
AST for nautobot_dns_models/tests/test_api.py
AST for nautobot_dns_models/tests/test_filters.py
AST for nautobot_dns_models/api/serializers.py
AST for nautobot_dns_models/api/__init__.py
AST for nautobot_dns_models/api/urls.py
AST for nautobot_dns_models/api/views.py
Linting 23 modules.
nautobot_dns_models/__init__.py (1 of 23)
nautobot_dns_models/template_content.py (2 of 23)
nautobot_dns_models/models.py (3 of 23)
nautobot_dns_models/_issue216_demo.py (4 of 23)
************* Module nautobot_dns_models._issue216_demo
nautobot_dns_models/_issue216_demo.py:4:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
nautobot_dns_models/_issue216_demo.py:1:0: C0114: Missing module docstring (missing-module-docstring)
nautobot_dns_models/_issue216_demo.py:1:0: C0410: Multiple imports on one line (os, sys) (multiple-imports)
nautobot_dns_models/_issue216_demo.py:3:0: C0116: Missing function or method docstring (missing-function-docstring)
nautobot_dns_models/_issue216_demo.py:6:0: C0103: Constant name "result" doesn't conform to UPPER_CASE naming style (invalid-name)
nautobot_dns_models/_issue216_demo.py:1:0: W0611: Unused import os (unused-import)
nautobot_dns_models/_issue216_demo.py:1:0: W0611: Unused import sys (unused-import)
nautobot_dns_models/forms.py (5 of 23)
nautobot_dns_models/jobs.py (6 of 23)
nautobot_dns_models/filter_extensions.py (7 of 23)
nautobot_dns_models/tables.py (8 of 23)
nautobot_dns_models/navigation.py (9 of 23)
nautobot_dns_models/urls.py (10 of 23)
nautobot_dns_models/filters.py (11 of 23)
nautobot_dns_models/views.py (12 of 23)
nautobot_dns_models/tests/test_forms.py (13 of 23)
nautobot_dns_models/tests/__init__.py (14 of 23)
nautobot_dns_models/tests/test_views.py (15 of 23)
nautobot_dns_models/tests/test_models.py (16 of 23)
nautobot_dns_models/tests/test_jobs.py (17 of 23)
nautobot_dns_models/tests/test_api.py (18 of 23)
nautobot_dns_models/tests/test_filters.py (19 of 23)
nautobot_dns_models/api/serializers.py (20 of 23)
nautobot_dns_models/api/__init__.py (21 of 23)
nautobot_dns_models/api/urls.py (22 of 23)
nautobot_dns_models/api/views.py (23 of 23)

-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Your code has been rated at 9.98/10 (previous run: 10.00/10, -0.02)
```
#### `ruff --diff` (new syntax)
```bash
invoke ruff --action lint --diff --target nautobot_dns_models/_issue216_demo.py
```

```diff
--- nautobot_dns_models/_issue216_demo.py
+++ nautobot_dns_models/_issue216_demo.py
@@ -1,4 +1,3 @@
-import os, sys

 def add(a,b):
   return  a+b
```

#### `ruff` lint without `--diff` (existing syntax)
```bash
invoke ruff --action lint --target nautobot_dns_models/_issue216_demo.py

Running docker compose command "exec nautobot ruff check --output-format concise nautobot_dns_models/_issue216_demo.py"
nautobot_dns_models/_issue216_demo.py:1:1: E401 Multiple imports on one line
nautobot_dns_models/_issue216_demo.py:1:1: I001 Import block is un-sorted or un-formatted
nautobot_dns_models/_issue216_demo.py:1:8: F401 `os` imported but unused
nautobot_dns_models/_issue216_demo.py:1:12: F401 `sys` imported but unused
Found 4 errors.
[*] 4 fixable with the `--fix` option.
```

#### `ruff format --diff` (new syntax)
```bash
invoke ruff --action format --diff --target nautobot_dns_models/_issue216_demo.py
```

```diff
--- nautobot_dns_models/_issue216_demo.py
+++ nautobot_dns_models/_issue216_demo.py
@@ -1,7 +1,9 @@
 import os, sys

-def add(a,b):
-  return  a+b
+def add(a, b):
+    return a + b

-result= add(1,2)
-print( result )
+result = add(1, 2)
+print(result)
```

#### `ruff format` without `--diff` (existing syntax)
```bash
invoke ruff --action format --target nautobot_dns_models/_issue216_demo.py

Running docker compose command "exec nautobot ruff format --check nautobot_dns_models/_issue216_demo.py"
Would reformat: nautobot_dns_models/_issue216_demo.py
1 file would be reformatted
```

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
