### PR TITLE
Add FQDN Mixin to filterset for FQDN search on A and AAAA

### DIFF
--- a/changes/228.added
+++ b/changes/228.added
@@ -1,0 +1,1 @@
+Added functionality to global search using FQDN.

--- a/nautobot_dns_models/filters.py
+++ b/nautobot_dns_models/filters.py
@@ -1,8 +1,8 @@
 """Filtering for nautobot_dns_models."""
 
 import django_filters
-from django.db.models import F
-from django.db.models.functions import Coalesce
+from django.db.models import CharField, F, Value
+from django.db.models.functions import Coalesce, Concat
 from nautobot.apps.filters import NautobotFilterSet, SearchFilter, TenancyModelFilterSetMixin
 from nautobot.core.filters import MultiValueCharFilter, NaturalKeyOrPKMultipleChoiceFilter
 from netaddr import IPAddress as NetIPAddress
@@ -142,6 +142,17 @@ class DNSRecordFilterSet(NautobotFilterSet):
         return queryset.exclude(effective_ttl=value)
 
 
+class FqdnSearchMixin:
+    """Make a DNS record filterset searchable by full FQDN."""
+
+    def __init__(self, *args, **kwargs):
+        """Annotate the base queryset with the computed FQDN."""
+        super().__init__(*args, **kwargs)
+        self.queryset = self.queryset.annotate(
+            fqdn=Concat(F("name"), Value("."), F("zone__name"), output_field=CharField()),
+        )
+
+
 class NSRecordFilterSet(DNSRecordFilterSet):
     """Filter for NSRecord."""
 
@@ -169,13 +180,14 @@ def ip_address_preprocessor(value):
     return value
 
 
-class ARecordFilterSet(DNSRecordFilterSet):
+class ARecordFilterSet(FqdnSearchMixin, DNSRecordFilterSet):
     """Filter for ARecord."""
 
     q = SearchFilter(
         filter_predicates={
             "name": "icontains",
             "zone__name": "icontains",
+            "fqdn": "icontains",
             "ip_address__host": {"lookup_expr": "net_host", "preprocessor": ip_address_preprocessor},
         }
     )
@@ -187,13 +199,14 @@ class ARecordFilterSet(DNSRecordFilterSet):
         fields = "__all__"
 
 
-class AAAARecordFilterSet(DNSRecordFilterSet):
+class AAAARecordFilterSet(FqdnSearchMixin, DNSRecordFilterSet):
     """Filter for AAAARecord."""
 
     q = SearchFilter(
         filter_predicates={
             "name": "icontains",
             "zone__name": "icontains",
+            "fqdn": "icontains",
             "ip_address__host": {"lookup_expr": "net_host", "preprocessor": ip_address_preprocessor},
         }
     )

--- a/nautobot_dns_models/filters.py
+++ b/nautobot_dns_models/filters.py
@@ -1,7 +1,9 @@
 """Filtering for nautobot_dns_models."""
 
+import uuid
+
 import django_filters
-from django.db.models import CharField, F, Value
+from django.db.models import CharField, F, Q, Value
 from django.db.models.functions import Coalesce, Concat
 from nautobot.apps.filters import NautobotFilterSet, SearchFilter, TenancyModelFilterSetMixin
 from nautobot.core.filters import MultiValueCharFilter, NaturalKeyOrPKMultipleChoiceFilter
@@ -142,17 +144,6 @@ class DNSRecordFilterSet(NautobotFilterSet):
         return queryset.exclude(effective_ttl=value)
 
 
-class FqdnSearchMixin:
-    """Make a DNS record filterset searchable by full FQDN."""
-
-    def __init__(self, *args, **kwargs):
-        """Annotate the base queryset with the computed FQDN."""
-        super().__init__(*args, **kwargs)
-        self.queryset = self.queryset.annotate(
-            fqdn=Concat(F("name"), Value("."), F("zone__name"), output_field=CharField()),
-        )
-
-
 class NSRecordFilterSet(DNSRecordFilterSet):
     """Filter for NSRecord."""
 
@@ -180,17 +171,34 @@ def ip_address_preprocessor(value):
     return value
 
 
-class ARecordFilterSet(FqdnSearchMixin, DNSRecordFilterSet):
+def search_address_record(queryset, name, value):  # pylint: disable=unused-argument
+    """Search A/AAAA records by name, zone, full FQDN, or IP address."""
+    queryset = queryset.annotate(
+        fqdn=Concat("name", Value("."), "zone__name", output_field=CharField()),
+    )
+    query = Q(name__icontains=value) | Q(zone__name__icontains=value) | Q(fqdn__icontains=value)
+
+    try:
+        uuid.UUID(value)
+    except (ValueError, TypeError, AttributeError):
+        pass
+    else:
+        query |= Q(id=value)
+
+    try:
+        ip_value = ip_address_preprocessor(value)
+    except ValueError:
+        pass
+    else:
+        query |= Q(ip_address__host__net_host=ip_value)
+
+    return queryset.filter(query).distinct()
+
+
+class ARecordFilterSet(DNSRecordFilterSet):
     """Filter for ARecord."""
 
-    q = SearchFilter(
-        filter_predicates={
-            "name": "icontains",
-            "zone__name": "icontains",
-            "fqdn": "icontains",
-            "ip_address__host": {"lookup_expr": "net_host", "preprocessor": ip_address_preprocessor},
-        }
-    )
+    q = django_filters.CharFilter(method=search_address_record, label="Search")
 
     class Meta:
         """Meta attributes for filter."""
@@ -199,17 +207,10 @@ class ARecordFilterSet(FqdnSearchMixin, DNSRecordFilterSet):
         fields = "__all__"
 
 
-class AAAARecordFilterSet(FqdnSearchMixin, DNSRecordFilterSet):
+class AAAARecordFilterSet(DNSRecordFilterSet):
     """Filter for AAAARecord."""
 
-    q = SearchFilter(
-        filter_predicates={
-            "name": "icontains",
-            "zone__name": "icontains",
-            "fqdn": "icontains",
-            "ip_address__host": {"lookup_expr": "net_host", "preprocessor": ip_address_preprocessor},
-        }
-    )
+    q = django_filters.CharFilter(method=search_address_record, label="Search")
 
     class Meta:
         """Meta attributes for filter."""

--- a/nautobot_dns_models/tests/test_filters.py
+++ b/nautobot_dns_models/tests/test_filters.py
@@ -535,6 +535,9 @@ class ARecordFilterTestCase(TestCase):
         self.assertEqual(self.filterset({"q": "a-record"}, self.queryset).qs.count(), 3)
         self.assertEqual(self.filterset({"q": self.ip_addresses[0].host}, self.queryset).qs.count(), 1)
         self.assertEqual(self.filterset({"q": "example.com"}, self.queryset).qs.count(), 3)
+        # Full FQDN (record name + zone name) should match the single record.
+        self.assertEqual(self.filterset({"q": "a-record-01.example.com"}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"q": "a-record-01.example2.com"}, self.queryset).qs.count(), 0)
 
 
 class AAAARecordFilterTestCase(TestCase):
@@ -595,6 +598,9 @@ class AAAARecordFilterTestCase(TestCase):
         self.assertEqual(self.filterset({"q": "aaaa-record"}, self.queryset).qs.count(), 3)
         self.assertEqual(self.filterset({"q": self.ip_addresses[0].host}, self.queryset).qs.count(), 1)
         self.assertEqual(self.filterset({"q": "example.com"}, self.queryset).qs.count(), 3)
+        # Full FQDN (record name + zone name) should match the single record.
+        self.assertEqual(self.filterset({"q": "aaaa-record-01.example.com"}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"q": "aaaa-record-01.nonexistent.com"}, self.queryset).qs.count(), 0)
 
 
 class CNAMERecordFilterTestCase(TestCase):

--- a/tasks.py
+++ b/tasks.py
@@ -892,7 +892,9 @@ def djlint(context, target=None):
     command = "djlint --lint "
     command += " ".join(target)
 
-    exit_code = 0 if run_command(context, command, warn=True) else 1
+    # djlint exits 1 when there are no files to lint, treat that result as success.
+    result = run_command(context, command, warn=True)
+    exit_code = 0 if result or "No files to check" in result.stdout else 1
     if exit_code != 0:
         raise Exit(code=exit_code)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot DNS Models! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #228 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Adds a FQDN Mixin for filtersets to annotate a full FQDN that can then be filtered upon. 
<img width="1482" height="725" alt="Screenshot 2026-06-29 at 1 40 37 PM" src="https://github.com/user-attachments/assets/86ec8bce-3f21-4fa1-b4d5-d206ef314188" />

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [X] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
