### PR TITLE
Closes #234: Fix A/AAAARecord edit form load time

### DIFF
--- a/changes/234.fixed
+++ b/changes/234.fixed
@@ -1,0 +1,1 @@
+Fixed ARecord and AAAARecord edit forms taking a long time to load when many IP addresses are present.

--- a/nautobot_dns_models/forms.py
+++ b/nautobot_dns_models/forms.py
@@ -2,13 +2,15 @@
 
 from django import forms
 from nautobot.apps.forms import (
+    DynamicModelChoiceField,
     DynamicModelMultipleChoiceField,
     NautobotBulkEditForm,
     NautobotModelForm,
     TagsBulkEditFormMixin,
 )
 from nautobot.extras.forms import NautobotFilterForm
-from nautobot.ipam.models import Prefix
+from nautobot.ipam.choices import IPAddressVersionChoices
+from nautobot.ipam.models import IPAddress, Prefix
 
 from nautobot_dns_models import models
 
@@ -146,6 +148,12 @@ class NSRecordFilterForm(NautobotFilterForm):
 class ARecordForm(NautobotModelForm):
     """ARecord creation/edit form."""
 
+    address = DynamicModelChoiceField(
+        queryset=IPAddress.objects.all(),
+        required=True,
+        query_params={"ip_version": IPAddressVersionChoices.VERSION_4},
+    )
+
     class Meta:
         """Meta attributes."""
 
@@ -188,6 +196,12 @@ class ARecordFilterForm(NautobotFilterForm):
 
 class AAAARecordForm(NautobotModelForm):
     """AAAARecord creation/edit form."""
+
+    address = DynamicModelChoiceField(
+        queryset=IPAddress.objects.all(),
+        required=True,
+        query_params={"ip_version": IPAddressVersionChoices.VERSION_6},
+    )
 
     class Meta:
         """Meta attributes."""


### PR DESCRIPTION
Use dynamic IP address fields to avoid loading every IP address when rendering A and AAAA record forms.

<!--
    Thank you for your interest in contributing to Nautobot DNS Models! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #234 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Added `address` attribute to `ARecord` and `AAAARecord` forms so that the the IP is included in the query used to load the edit page.

### SQL Before

```
2026-07-23 16:10:58.199 UTC [44986] LOG:  statement: DECLARE "_django_curs_281465753432448_sync_5" NO SCROLL CURSOR WITH HOLD FOR SELECT "ipam_ipaddress"."id", "ipam_ipaddress"."created", "ipam_ipaddress"."last_updated", "ipam_ipaddress"."_custom_field_data", "ipam_ipaddress"."host", "ipam_ipaddress"."mask_length", "ipam_ipaddress"."type", "ipam_ipaddress"."status_id", "ipam_ipaddress"."role_id", "ipam_ipaddress"."parent_id", "ipam_ipaddress"."ip_version", "ipam_ipaddress"."tenant_id", "ipam_ipaddress"."nat_inside_id", "ipam_ipaddress"."dns_name", "ipam_ipaddress"."description" FROM "ipam_ipaddress" WHERE EXISTS(SELECT 1 AS "a" FROM "ipam_ipaddress" U0 WHERE (U0."ip_version" = 4 AND U0."id" = ("ipam_ipaddress"."id")) LIMIT 1) ORDER BY "ipam_ipaddress"."ip_version" ASC, "ipam_ipaddress"."host" ASC, "ipam_ipaddress"."mask_length" ASC
2026-07-23 16:11:10.783 UTC [44986] LOG:  statement: FETCH FORWARD 2000 FROM "_django_curs_281465753432448_sync_5"
2026-07-23 16:11:10.826 UTC [44986] LOG:  statement: FETCH FORWARD 2000 FROM "_django_curs_281465753432448_sync_5"
2026-07-23 16:11:10.860 UTC [44986] LOG:  statement: FETCH FORWARD 2000 FROM "_django_curs_281465753432448_sync_5"

[...]

2026-07-23 16:12:30.124 UTC [44986] LOG:  statement: CLOSE "_django_curs_281465753432448_sync_5"
```

### SQL After

```
2026-07-23 16:56:43.301 UTC [47092] LOG:  statement: DECLARE "_django_curs_281473113780608_sync_2" NO SCROLL CURSOR WITH HOLD FOR SELECT "ipam_ipaddress"."id", "ipam_ipaddress"."created", "ipam_ipaddress"."last_updated", "ipam_ipaddress"."_custom_field_data", "ipam_ipaddress"."host", "ipam_ipaddress"."mask_length", "ipam_ipaddress"."type", "ipam_ipaddress"."status_id", "ipam_ipaddress"."role_id", "ipam_ipaddress"."parent_id", "ipam_ipaddress"."ip_version", "ipam_ipaddress"."tenant_id", "ipam_ipaddress"."nat_inside_id", "ipam_ipaddress"."dns_name", "ipam_ipaddress"."description" FROM "ipam_ipaddress" WHERE "ipam_ipaddress"."id" = '89133942-70ec-489d-b3e4-f7c9b1dd8cf4'::uuid ORDER BY "ipam_ipaddress"."ip_version" ASC, "ipam_ipaddress"."host" ASC, "ipam_ipaddress"."mask_length" ASC
2026-07-23 16:56:43.303 UTC [47092] LOG:  statement: FETCH FORWARD 2000 FROM "_django_curs_281473113780608_sync_2"
2026-07-23 16:56:43.304 UTC [47092] LOG:  statement: FETCH FORWARD 2000 FROM "_django_curs_281473113780608_sync_2"
2026-07-23 16:56:43.304 UTC [47092] LOG:  statement: CLOSE "_django_curs_281473113780608_sync_2"
```

### BEFORE: page load time w/ 1k `ARecord` objects

<img width="770" height="21" alt="Screenshot 2026-07-23 at 3 55 06 PM" src="https://github.com/user-attachments/assets/bbafecc2-ff2f-4caa-ba3b-515046bbf84c" />

### BEFORE: page load time w/250k `ARecord` objects

<img width="773" height="22" alt="Screenshot 2026-07-23 at 3 56 36 PM" src="https://github.com/user-attachments/assets/f9c53577-64da-4559-8f82-f2f4f8df3c40" />

### AFTER: page load time w/250k `ARecord` objects
<img width="758" height="25" alt="Screenshot 2026-07-23 at 3 57 04 PM" src="https://github.com/user-attachments/assets/e1eda5b0-6553-4715-94fb-036c0fa1443b" />


## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
