### PR TITLE
fix: auto-create ptr field to use proper widget

### DIFF
--- a/changes/243.fixed
+++ b/changes/243.fixed
@@ -1,0 +1,1 @@
+Fixed auto-create PTR records field to look the same as the other boolean fields in buld edit form.

--- a/nautobot_dns_models/forms.py
+++ b/nautobot_dns_models/forms.py
@@ -257,7 +257,9 @@ class DNSZoneBulkEditForm(TagsBulkEditFormMixin, NautobotBulkEditForm):
         queryset=Tenant.objects.all(),
         required=False,
     )
-    auto_create_ptr = forms.NullBooleanField(required=False, label="Auto-create PTR Records")
+    auto_create_ptr = forms.NullBooleanField(
+        required=False, label="Auto-create PTR Records", widget=BulkEditNullBooleanSelect
+    )
     enabled = forms.NullBooleanField(required=False, widget=BulkEditNullBooleanSelect)
 
     class Meta:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot DNS Models! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #243 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Changed the field in bulk edit form to use the proper widget and look like the other boolean fields. 
<img width="749" height="199" alt="image" src="https://github.com/user-attachments/assets/8d2d8473-7630-49cc-9a22-c90670df5a95" />

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
