### PR TITLE
Bug Fix: Match disabled icon on table to details page

### DIFF
--- a/changes/259.fixed
+++ b/changes/259.fixed
@@ -1,0 +1,1 @@
+Fixed the `Auto-create PTR Records` column in the DNS Zone table to render the same check/X icons as the detail view and the other boolean columns, instead of plain Unicode characters.

--- a/nautobot_dns_models/tables.py
+++ b/nautobot_dns_models/tables.py
@@ -131,6 +131,7 @@ class DNSZoneTable(BaseTable):
     tenant = TenantColumn()
     dns_view = tables.Column(linkify=True)
     enabled = BooleanColumn()
+    auto_create_ptr = BooleanColumn()
     actions = ButtonsColumn(
         models.DNSZone,
         buttons=("changelog", "edit", "delete"),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot DNS Models! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #259 

## What's Changed

Made the `Auto-create PTR Records` column a BolleanColumn() instead of a default column.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example