### PR TITLE
Closes #266: Accept valid SOA RNAME values in DNS Zone bulk edit

### DIFF
--- a/changes/266.fixed
+++ b/changes/266.fixed
@@ -1,0 +1,1 @@
+Fixed DNS Zone bulk edit rejecting valid SOA RNAME values.

--- a/nautobot_dns_models/forms.py
+++ b/nautobot_dns_models/forms.py
@@ -291,9 +291,10 @@ class DNSZoneBulkEditForm(TagsBulkEditFormMixin, NautobotBulkEditForm):
         help_text="FQDN of the Authoritative Name Server for Zone.",
         label="SOA MNAME",
     )
-    soa_rname = forms.EmailField(
+    soa_rname = forms.CharField(
         required=False,
-        help_text="Admin Email for the Zone in the form",
+        max_length=254,
+        help_text="Mailbox of the person responsible for the zone or a single-label placeholder.",
         label="SOA RNAME",
     )
     soa_refresh = forms.IntegerField(

--- a/nautobot_dns_models/tests/test_forms.py
+++ b/nautobot_dns_models/tests/test_forms.py
@@ -1,5 +1,6 @@
 """Tests for nautobot_dns_models Form Classes."""
 
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from nautobot.extras.models.statuses import Status
 from nautobot.ipam.models import IPAddress, Namespace, Prefix
@@ -137,6 +138,62 @@ class DNSZoneTest(TestCase):
             }
         )
         self.assertTrue(form.is_valid())
+
+
+class DNSZoneBulkEditFormTest(TestCase):
+    """Test DNSZone bulk edit form SOA RNAME handling."""
+
+    form_class = forms.DNSZoneBulkEditForm
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.zone = DNSZone.objects.create(
+            name="bulk-rname.example",
+            filename="bulk-rname.example.zone",
+            soa_mname="ns1.bulk-rname.example.",
+            soa_rname="admin@example.com",
+        )
+
+    def test_soa_rname_accepts_dns_style_mailbox(self):
+        form = self.form_class(
+            DNSZone,
+            data={"pk": [self.zone.pk], "soa_rname": "admin.example.com"},
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        self.zone.soa_rname = form.cleaned_data["soa_rname"]
+        self.zone.validated_save()
+        self.zone.refresh_from_db()
+        self.assertEqual(self.zone.soa_rname, "admin@example.com")
+
+    def test_soa_rname_accepts_single_label_placeholder(self):
+        form = self.form_class(
+            DNSZone,
+            data={"pk": [self.zone.pk], "soa_rname": "invalid."},
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        self.zone.soa_rname = form.cleaned_data["soa_rname"]
+        self.zone.validated_save()
+        self.zone.refresh_from_db()
+        self.assertEqual(self.zone.soa_rname, "invalid")
+
+    def test_soa_rname_rejects_invalid_value(self):
+        form = self.form_class(
+            DNSZone,
+            data={"pk": [self.zone.pk], "soa_rname": "john.example"},
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        self.zone.soa_rname = form.cleaned_data["soa_rname"]
+        with self.assertRaises(ValidationError) as context:
+            self.zone.validated_save()
+        self.assertIn("soa_rname", context.exception.message_dict)
+        self.assertIn(
+            "SOA RNAME must be a valid email address, a basic DNS-style mailbox with a fully qualified domain, "
+            "or a single-label placeholder.",
+            context.exception.message_dict["soa_rname"],
+        )
 
 
 class DNSRegistrarFormTestCase(TestCase):

--- a/nautobot_dns_models/tests/test_views.py
+++ b/nautobot_dns_models/tests/test_views.py
@@ -184,7 +184,12 @@ class DnsZoneViewTest(ViewTestCases.PrimaryObjectViewTestCase):
             f"Test 3, {dns_view.id}, 3600, Description 3, filename 3, auth-server, admin@example_three.com, 86400, 7200, 3600000, 0, 172800",
         )
 
-        cls.bulk_edit_data = {"description": "Bulk edit views", "enabled": False}
+        cls.bulk_edit_data = {
+            "description": "Bulk edit views",
+            "enabled": False,
+            # DNSZone.soa_rname accepts a DNS-style mailbox, not only an email address
+            "soa_rname": "admin.example.com",
+        }
 
 
 class NSRecordViewTest(ViewTestCases.PrimaryObjectViewTestCase):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot DNS Models! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #266

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Fixed a bug in which the `DNSZone` bulk edit form wouldn't accept values for which was support was added in #224 

https://github.com/user-attachments/assets/6bf057e3-814e-4aae-b1a2-5e6c75d8aa15


Note that `invalid.` is correctly normalized to `invalid`, the same behavior seen in a single-zone edit.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
