### PR TITLE
Closes #268: Fixed filter tests that asserted their own fixture's row count instead of exercising the named filter

### DIFF
--- a/changes/268.housekeeping
+++ b/changes/268.housekeeping
@@ -1,0 +1,1 @@
+Fixed fourteen filter tests that asserted their own fixture's row count instead of exercising the named filter.

--- a/nautobot_dns_models/tests/test_filters.py
+++ b/nautobot_dns_models/tests/test_filters.py
@@ -369,9 +369,9 @@ class DNSZoneFilterTestCase(FilterTestCases.FilterTestCase, FilterTestCases.Tena
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
-        """Test using Q search with name of DNSZone."""
-        params = {"name__in": "Test"}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+        """Test case-insensitive substring filter on name of DNSZone."""
+        self.assertEqual(self.filterset({"name__ic": "TEST T"}, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset({"name__ic": "Test"}, self.queryset).qs.count(), 3)
 
     def test_name_invalid(self):
         """Test using invalid Q search for DNSZone."""

--- a/nautobot_dns_models/tests/test_filters.py
+++ b/nautobot_dns_models/tests/test_filters.py
@@ -425,10 +425,11 @@ class NSRecordFilterTestCase(TestCase):
         params = {"server": "ns1.example.com"}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
-    def test_server_in(self):
-        """Test using Q search with server of NSRecord."""
-        params = {"server__in": "example.com"}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+    def test_server_ic(self):
+        """Test case-insensitive substring filter on server of NSRecord."""
+        self.assertEqual(self.filterset({"server__ic": "NS2.EXAMPLE"}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"server__ic": "example.com"}, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset({"server__ic": "ns4"}, self.queryset).qs.count(), 0)
 
     def test_server_invalid(self):
         """Test using invalid Q search for server of NSRecord."""
@@ -585,9 +586,9 @@ class AAAARecordFilterTestCase(TestCase):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
-        """Test filter with name of AAAARecord."""
-        params = {"name__in": "aaaa-record"}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+        """Test case-insensitive substring filter on name of AAAARecord."""
+        self.assertEqual(self.filterset({"name__ic": "AAAA-RECORD-02"}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"name__ic": "aaaa-record"}, self.queryset).qs.count(), 3)
 
     def test_name_invalid(self):
         """Test using invalid search for AAAARecord."""
@@ -637,9 +638,9 @@ class CNAMERecordFilterTestCase(TestCase):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
-        """Test filter with name of CNAMERecord."""
-        params = {"name__in": "cname-record"}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        """Test case-insensitive substring filter on name of CNAMERecord."""
+        self.assertEqual(self.filterset({"name__ic": "CNAME-RECORD-01"}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"name__ic": "cname-record"}, self.queryset).qs.count(), 2)
 
     def test_name_invalid(self):
         """Test using invalid search for CNAMERecord."""
@@ -651,10 +652,10 @@ class CNAMERecordFilterTestCase(TestCase):
         params = {"alias": "site.example.com"}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
-    def test_alias_in(self):
-        """Test alias in CNAMERecord."""
-        params = {"alias__in": "example.com"}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+    def test_alias_ic(self):
+        """Test case-insensitive substring filter on alias of CNAMERecord."""
+        self.assertEqual(self.filterset({"alias__ic": "BLOG."}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"alias__ic": "example.com"}, self.queryset).qs.count(), 2)
 
     def test_alias_invalid(self):
         params = {"alias": "wrong-alias"}
@@ -690,9 +691,9 @@ class MXRecordFilterTestCase(TestCase):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
-        """Test filter with name of MXRecord."""
-        params = {"name__in": "mx-record"}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        """Test case-insensitive substring filter on name of MXRecord."""
+        self.assertEqual(self.filterset({"name__ic": "MX-RECORD-01"}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"name__ic": "mx-record"}, self.queryset).qs.count(), 2)
 
     def test_name_invalid(self):
         """Test using invalid search for MXRecord."""
@@ -704,10 +705,10 @@ class MXRecordFilterTestCase(TestCase):
         params = {"mail_server": "mail.example.com"}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
-    def test_mail_server_in(self):
-        """Test mail server in MXRecord."""
-        params = {"mail_server__in": "example.com"}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+    def test_mail_server_ic(self):
+        """Test case-insensitive substring filter on mail server of MXRecord."""
+        self.assertEqual(self.filterset({"mail_server__ic": "MAIL-02"}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"mail_server__ic": "example.com"}, self.queryset).qs.count(), 2)
 
     def test_mail_server_invalid(self):
         params = {"mail_server": "wrong-mail-server"}
@@ -743,9 +744,9 @@ class TXTRecordFilterTestCase(TestCase):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
-        """Test filter with name of TXTRecord."""
-        params = {"name__in": "txt-record"}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        """Test case-insensitive substring filter on name of TXTRecord."""
+        self.assertEqual(self.filterset({"name__ic": "TXT-RECORD-02"}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"name__ic": "txt-record"}, self.queryset).qs.count(), 2)
 
     def test_name_invalid(self):
         """Test using invalid search for TXTRecord."""
@@ -757,10 +758,10 @@ class TXTRecordFilterTestCase(TestCase):
         params = {"text": "spf-record"}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
-    def test_text_in(self):
-        """Test text in TXTRecord."""
-        params = {"text__in": "record"}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+    def test_text_ic(self):
+        """Test case-insensitive substring filter on text of TXTRecord."""
+        self.assertEqual(self.filterset({"text__ic": "SPF"}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"text__ic": "record"}, self.queryset).qs.count(), 2)
 
     def test_text_invalid(self):
         params = {"text": "wrong-text"}
@@ -796,9 +797,9 @@ class PTRRecordFilterTestCase(TestCase):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
-        """Test filter with name of PTRRecord."""
-        params = {"name__in": "ptr-record"}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        """Test case-insensitive substring filter on name of PTRRecord."""
+        self.assertEqual(self.filterset({"name__ic": "PTR-RECORD-01"}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"name__ic": "ptr-record"}, self.queryset).qs.count(), 2)
 
     def test_name_invalid(self):
         """Test using invalid search for PTRRecord."""
@@ -810,10 +811,10 @@ class PTRRecordFilterTestCase(TestCase):
         params = {"ptrdname": "ptr-record-01"}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
-    def test_ptrdname_in(self):
-        """Test ptrdname in PTRRecord."""
-        params = {"ptrdname__in": "ptr-record"}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+    def test_ptrdname_ic(self):
+        """Test case-insensitive substring filter on ptrdname of PTRRecord."""
+        self.assertEqual(self.filterset({"ptrdname__ic": "PTR-RECORD-02"}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"ptrdname__ic": "ptr-record"}, self.queryset).qs.count(), 2)
 
     def test_ptrdname_invalid(self):
         params = {"ptrdname": "wrong-ptrdname"}

--- a/nautobot_dns_models/tests/test_filters.py
+++ b/nautobot_dns_models/tests/test_filters.py
@@ -533,10 +533,10 @@ class ARecordFilterTestCase(TestCase):
         params = {"ip_address": [self.ip_addresses[0]]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
-    def test_ipaddress_in(self):
-        """Test ip_address in ARecord."""
-        params = {"ip_address__in": "10.0.0."}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+    def test_ipaddress_multiple(self):
+        """Test search with multiple IP addresses of ARecord."""
+        params = {"ip_address": [self.ip_addresses[0], self.ip_addresses[1]]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_zone(self):
         params = {"zone": [self.zone]}
@@ -600,10 +600,10 @@ class AAAARecordFilterTestCase(TestCase):
         params = {"ip_address": [self.ip_addresses[0]]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
-    def test_ip_address_in(self):
-        """Test ip_address in AAAARecord."""
-        params = {"ip_address__in": "2001:db8:abcd:12::"}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+    def test_ip_address_multiple(self):
+        """Test search with multiple IP addresses of AAAARecord."""
+        params = {"ip_address": [self.ip_addresses[0], self.ip_addresses[1]]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_zone(self):
         params = {"zone": [self.zone]}

--- a/nautobot_dns_models/tests/test_filters.py
+++ b/nautobot_dns_models/tests/test_filters.py
@@ -871,10 +871,10 @@ class SRVRecordFilterTestCase(TestCase):
         params = {"name": "_sip._tcp"}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
-    def test_name(self):
-        """Test filter with name of SRVRecord."""
-        params = {"name__in": "_sip._tcp,_xmpp._tcp"}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+    def test_name_multiple(self):
+        """Test filter with multiple name values of SRVRecord."""
+        self.assertEqual(self.filterset({"name": ["_xmpp._tcp"]}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"name": ["_sip._tcp", "_xmpp._tcp"]}, self.queryset).qs.count(), 3)
 
     def test_name_invalid(self):
         """Test using invalid search for SRVRecord."""


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot DNS Models! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #268 
## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Fourteen assertions in `nautobot_dns_models/tests/test_filters.py` filtered on a `<field>__in` parameter that no filterset in this app generates. Nautobot builds `ic`, `nic`, `ie`, `nie`, `isw`, `nisw`, `iew`, `niew`, `re`, `nre`, `ire`, `nire`, and `n` for character fields, and only `ip_address` and `ip_address__n` for the `ip_address` relation. The filterset does report the
unknown parameter through `is_valid()` and `errors`, but these tests read `.qs` directly, which returns the unfiltered queryset. Each assertion therefore compared the fixture total to itself and could not fail.

## Proof the old tests didn't work as advertised 

On unmodified `develop` (826131e), replace all fourteen `__in` filter values with the same nonsense string and run only those fourteen tests:

```
mutated 14 __in values
Found 14 test(s).
..............
Ran 14 tests in 0.670s

OK
```

## Proof the new tests can fail

The same treatment applied to the corrected assertions — nonsense substrings for every `__ic` value, a nonexistent name list for SRV, and one address where two are expected:

```
mutated 25 __ic values and 4 multi-value assertions
Found 14 test(s).
Ran 14 tests in 0.565s

FAILED (failures=14)
```

All fourteen fail.

## A working example

`TXTRecordFilterTestCase` creates exactly two records:

```python
    @classmethod
    def setUpTestData(cls):
        cls.zone = DNSZone.objects.create(name="example.com")
        TXTRecord.objects.create(name="txt-record-01", text="spf-record", zone=cls.zone)
        TXTRecord.objects.create(name="txt-record-02", text="dkim-record", zone=cls.zone)
```

The test on `develop`, with its filter value replaced by a string that matches nothing:

```python
    def test_text_in(self):
        """Test text in TXTRecord."""
        params = {"text__in": "ZZZ-NO-SUCH-VALUE"}
        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
```

```
$ invoke unittest --keepdb --skip-docs-build \
    --label nautobot_dns_models.tests.test_filters.TXTRecordFilterTestCase.test_text_in
Ran 1 test in 0.038s

OK
```

It passes on garbage input. `text__in` is not a filter this filterset defines, so it is discarded, the queryset comes back unfiltered at two rows, and the expected value of `2` is the fixture total. The assertion is comparing the fixture to itself.

The replacement, given the same treatment:

```python
    def test_text_ic(self):
        """Test case-insensitive substring filter on text of TXTRecord."""
        self.assertEqual(self.filterset({"text__ic": "ZZZ-NO-SUCH-VALUE"}, self.queryset).qs.count(), 1)
        self.assertEqual(self.filterset({"text__ic": "record"}, self.queryset).qs.count(), 2)
```

```
FAIL: test_text_ic (nautobot_dns_models.tests.test_filters.TXTRecordFilterTestCase)
Test case-insensitive substring filter on text of TXTRecord.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/source/nautobot_dns_models/tests/test_filters.py", line 763, in test_text_ic
    self.assertEqual(self.filterset({"text__ic": "ZZZ-NO-SUCH-VALUE"}, self.queryset).qs.count(), 1)
AssertionError: 0 != 1

Ran 1 test in 0.034s

FAILED (failures=1)
```

The committed version of that first line uses `"SPF"`, which matches one of the two rows and so distinguishes a working filter from a broken one, and is case-insensitive against the stored `spf-record`. The second line keeps the original `"record"` substring, which matches both rows.

## What changed, test by test

Every row follows the same pattern: the old expected count equalled the fixture total, and the new one adds a value matching a strict subset, so the assertion can now tell a working filter from a broken one.

| Test (before → after) | Before | After |
| --- | --- | --- |
| `DNSZoneFilterTestCase.test_name` | `name__in="Test"` → 3 | `name__ic="TEST T"` → 2; `="Test"` → 3 |
| `NSRecord.test_server_in` → `test_server_ic` | `server__in="example.com"` → 3 | `="NS2.EXAMPLE"` → 1; `="example.com"` → 3; `="ns4"` → 0 |
| `ARecord.test_ipaddress_in` → `test_ipaddress_multiple` | `ip_address__in="10.0.0."` → 3 | `ip_address=[addr0, addr1]` → 2 |
| `AAAARecord.test_name` | `name__in="aaaa-record"` → 3 | `="AAAA-RECORD-02"` → 1; `="aaaa-record"` → 3 |
| `AAAARecord.test_ip_address_in` → `test_ip_address_multiple` | `ip_address__in="2001:db8:abcd:12::"` → 3 | `ip_address=[addr0, addr1]` → 2 |
| `CNAME.test_name` | `name__in="cname-record"` → 2 | `="CNAME-RECORD-01"` → 1; `="cname-record"` → 2 |
| `CNAME.test_alias_in` → `test_alias_ic` | `alias__in="example.com"` → 2 | `="BLOG."` → 1; `="example.com"` → 2 |
| `MX.test_name` | `name__in="mx-record"` → 2 | `="MX-RECORD-01"` → 1; `="mx-record"` → 2 |
| `MX.test_mail_server_in` → `test_mail_server_ic` | `mail_server__in="example.com"` → 2 | `="MAIL-02"` → 1; `="example.com"` → 2 |
| `TXT.test_name` | `name__in="txt-record"` → 2 | `="TXT-RECORD-02"` → 1; `="txt-record"` → 2 |
| `TXT.test_text_in` → `test_text_ic` | `text__in="record"` → 2 | `="SPF"` → 1; `="record"` → 2 |
| `PTR.test_name` | `name__in="ptr-record"` → 2 | `="PTR-RECORD-01"` → 1; `="ptr-record"` → 2 |
| `PTR.test_ptrdname_in` → `test_ptrdname_ic` | `ptrdname__in="ptr-record"` → 2 | `="PTR-RECORD-02"` → 1; `="ptr-record"` → 2 |
| `SRV.test_name` → `test_name_multiple` | `name__in="_sip._tcp,_xmpp._tcp"` → 3 | `name=["_xmpp._tcp"]` → 1; `=["_sip._tcp","_xmpp._tcp"]` → 3 |

## Reproducing the baseline

```bash
$ git checkout 826131e -- nautobot_dns_models/tests/test_filters.py
$ python3 - <<'PY'
import re
path = "nautobot_dns_models/tests/test_filters.py"
with open(path, encoding="utf-8") as handle:
    text = handle.read()
text, count = re.subn(r'(__in":\s*)"[^"]*"', r'\1"ZZZ-NO-SUCH-VALUE"', text)
print(f"mutated {count} __in values")
with open(path, "w", encoding="utf-8") as handle:
    handle.write(text)
PY
$ invoke unittest --keepdb --skip-docs-build --label nautobot_dns_models.tests.test_filters
$ git checkout HEAD -- nautobot_dns_models/tests/test_filters.py
```

The module label above runs the whole file; to see exactly `Ran 14 tests`, pass the fourteen test labels from the table instead. `826131e` is the current `develop` tip, so substitute the merge base if `develop` moves before this merges.

## Other notes
The test harness could probably do with a refactor, for example inheriting from `FilterTestCases.FilterTestCase` and possibly using base test classes for the DNS records to reduce code duplication. This is deliberately a low-touch patch to fix the functional issue with these tests.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
